### PR TITLE
Implementation 3D displacements in Carbonate growth and Wave forcing modules

### DIFF
--- a/badlands/badlands/forcing/forceSim.py
+++ b/badlands/badlands/forcing/forceSim.py
@@ -704,65 +704,298 @@ class forceSim:
             return update
 
     def apply_XY_displacements(
-        self,
-        area,
-        fixIDs,
-        telev,
-        tcum,
-        hcum,
-        fcum,
-        wcum,
-        tflex=None,
-        scum=None,
-        Te=None,
-        Ke=None,
-        flexure=0,
-        strat=0,
-        ero=0,
-    ):
+            self,
+            area,
+            fixIDs,
+            telev,
+            tcum,
+            hcum,
+            fcum,
+            wcum,
+            tflex=None,
+            scum=None,
+            Te=None,
+            Ke=None,
+            flexure=0,
+            strat=0,
+            ero=0,
+        ):
+            """
+            Apply horizontal displacements and check if any point needs to be merged.
+            Args:
+                area : float averaged area of the irregular grid delaunay cells.
+                fixIDs : integer number of unstructured vertices which needs to stay fix (edges and borders nodes).
+                elev : float numpy array with elevation of previous TIN nodes.
+                tcum : float numpy array with erosion/deposition values from previous TIN nodes.
+                tflex : float numpy array with cumulative flexural values from previous TIN nodes.
+                scum : float numpy array with erosion/deposition used for stratal mesh.
+                hcum : float numpy array with erosion/deposition for hillslope used for stratal mesh.
+                wcum : float numpy array with erosion/deposition for wave used for stratal mesh.
+                Te : float numpy array with thickness used for erosional mesh.
+                Ke : float numpy array with erodibility used for erosional mesh.
+                flexure : integer flagging flexural isostasy.
+                strat : integer flagging stratigraphic mesh model.
+                ero : integer flagging erosional mesh model.
+            Returns
+            -------
+            tinMesh
+                delaunay mesh generated after displacements.
+            newelev
+                numpy array containing the updated elevation for the new TIN.
+            newcum
+                numpy array containing the updated erosion/deposition values for the new TIN.
+            newhcum
+                numpy array containing the updated erosion/deposition values for hillslope in the new TIN.
+            newwcum
+                numpy array containing the updated erosion/deposition values for wave in the new TIN.
+            newcumf
+                numpy array containing the updated cumulative flexural values for the new TIN.
+            newscum
+                numpy array containing the updated erosion/deposition values used in the stratal mesh.
+            newKe
+                numpy array containing the updated erodibility values for the new TIN.
+            newTe
+                numpy array containing the updated thickness values used in the erosional mesh.
+            """
+
+            # Apply displacements to TIN points (excluding boundary points)
+            telev += self.dispZ
+            tXY = numpy.copy(self.tXY)
+            tXY[fixIDs:, 0] += self.dispX[fixIDs:]
+            tXY[fixIDs:, 1] += self.dispY[fixIDs:]
+
+            # Specify inside simulation area parameters
+            dx = tXY[1, 0] - tXY[0, 0]
+            minX = min(tXY[:fixIDs, 0]) + dx
+            minY = min(tXY[:fixIDs, 1]) + dx
+            maxX = max(tXY[:fixIDs, 0]) - dx
+            maxY = max(tXY[:fixIDs, 1]) - dx
+
+            # Find points outside the area
+            xID = numpy.where(
+                numpy.logical_or(tXY[fixIDs:, 0] <= minX, tXY[fixIDs:, 0] >= maxX)
+            )[0]
+            yID = numpy.where(
+                numpy.logical_or(tXY[fixIDs:, 1] <= minY, tXY[fixIDs:, 1] >= maxY)
+            )[0]
+            tIDs = numpy.concatenate((xID, yID), axis=0)
+            tID = numpy.unique(tIDs)
+            tID += fixIDs
+
+            # Delete outside domain points if any
+            if len(tID) > 0:
+                self.tXY = numpy.delete(tXY, tID, 0)
+                elev = numpy.delete(telev, tID, 0)
+                cum = numpy.delete(tcum, tID, 0)
+                hum = numpy.delete(hcum, tID, 0)
+                fum = numpy.delete(fcum, tID, 0)
+                if wcum is not None:
+                    wum = numpy.delete(wcum, tID, 0)
+                if flexure == 1:
+                    cumf = numpy.delete(tflex, tID, 0)
+                if strat == 1:
+                    stcum = numpy.delete(scum, tID, 0)
+                if ero == 1:
+                    lay = Ke.shape[1]
+                    mKe = numpy.zeros((len(cum), lay))
+                    mTe = numpy.zeros((len(cum), lay))
+                    for k in range(lay):
+                        mKe[:, k] = numpy.delete(Ke[:, k], tID, 0)
+                        mTe[:, k] = numpy.delete(Te[:, k], tID, 0)
+            else:
+                self.tXY = numpy.copy(tXY)
+                elev = telev
+                cum = tcum
+                hum = hcum
+                fum = fcum
+                if wcum is not None:
+                    ##### THERE WAS A TYPO HERE....
+                    wum = wcum
+                    #############
+                if flexure == 1:
+                    cumf = tflex
+                if strat == 1:
+                    stcum = scum
+                if ero == 1:
+                    lay = Ke.shape[1]
+                    mKe = Ke
+                    mTe = Te
+
+            # Create KDTree with deformed points and find points which needs to be merged
+            tree = cKDTree(self.tXY)
+            pairs = tree.query_pairs(self.merge3d)
+
+            # For points which require merging define a new point and
+            # interpolate parameters based on merged points
+            if len(pairs) > 0:
+                pairIDs = numpy.array(list(pairs))
+                nonfixIDs = numpy.where(pairIDs[:, 1] >= fixIDs)
+                tXY = numpy.copy(self.tXY)
+                self.tXY = numpy.delete(tXY, pairIDs[nonfixIDs, 1], 0)
+                elev = numpy.delete(elev, pairIDs[nonfixIDs, 1], 0)
+                cum = numpy.delete(cum, pairIDs[nonfixIDs, 1], 0)
+                hum = numpy.delete(hum, pairIDs[nonfixIDs, 1], 0)
+                fum = numpy.delete(fum, pairIDs[nonfixIDs, 1], 0)
+                if wcum is not None:
+                    wum = numpy.delete(wum, pairIDs[nonfixIDs, 1], 0)
+                if flexure == 1:
+                    cumf = numpy.delete(cumf, pairIDs[nonfixIDs, 1], 0)
+                if strat == 1:
+                    stcum = numpy.delete(stcum, pairIDs[nonfixIDs, 1], 0)
+
+                # Create KDTree with deformed points and find points which needs to be merged
+                tree = cKDTree(self.tXY)
+
+            newXY = self.tXY
+            newelev = elev
+            newcum = cum
+            newhcum = hum
+            newfcum = fum
+            if wcum is not None:
+                newwcum = wum
+            if flexure == 1:
+                newcumf = cumf
+            if strat == 1:
+                newscum = stcum
+            if ero == 1:
+                nKe = mKe
+                nTe = mTe
+
+            # Based on new points build the triangulation
+            tmpTIN = triangle.triangulate({"vertices": newXY}, "eqDa" + str(area))
+            idsX = numpy.where(
+                numpy.logical_and(
+                    tmpTIN["vertices"][:, 0] > minX, tmpTIN["vertices"][:, 0] < maxX
+                )
+            )
+            idsY = numpy.where(
+                numpy.logical_and(
+                    tmpTIN["vertices"][:, 1] > minY, tmpTIN["vertices"][:, 1] < maxY
+                )
+            )
+            insID = numpy.intersect1d(idsX, idsY)
+            tmpXY = numpy.zeros((fixIDs + len(insID), 2))
+            tmpXY[:fixIDs, :] = tXY[:fixIDs, :]
+            tmpXY[fixIDs:, :] = tmpTIN["vertices"][insID, :]
+            newTIN = triangle.triangulate({"vertices": tmpXY}, "eDa" + str(area))
+
+            # If some points have been added during the triangulation update the TIN
+            # interpolate neighbouring parameters to these new points
+            if len(newTIN["vertices"][:, 0]) > len(newXY[:, 0]):
+                addPts = newTIN["vertices"][len(newXY[:, 0]) :, :2]
+                dist, ids = tree.query(addPts, k=3)
+                weights = 1.0 / dist ** 2
+                if len(elev[ids].shape) == 3:
+                    zvals = elev[ids][:, :, 0]
+                    cumvals = cum[ids][:, :, 0]
+                    humvals = hum[ids][:, :, 0]
+                    fumvals = fum[ids][:, :, 0]
+                    if wcum is not None:
+                        wumvals = wum[ids][:, :, 0]
+                    if flexure == 1:
+                        cumfvals = cumf[ids][:, :, 0]
+                    if strat == 1:
+                        scumvals = stcum[ids][:, :, 0]
+                else:
+                    zvals = elev[ids]
+                    cumvals = cum[ids]
+                    humvals = hum[ids]
+                    fumvals = fum[ids]
+                    if wcum is not None:
+                        wumvals = wum[ids]
+                    if flexure == 1:
+                        cumfvals = cumf[ids]
+                    if strat == 1:
+                        scumvals = stcum[ids]
+                if ero == 1:
+                    Tevals = numpy.zeros((len(zvals), lay))
+                    Kevals = numpy.zeros((len(zvals), lay))
+                    for k in range(lay):
+                        if len(mTe[ids, k].shape) == 3:
+                            Tevals[:, k] = mTe[ids, k][:, :, 0]
+                            Kevals[:, k] = mKe[ids, k][:, :, 0]
+                        else:
+                            Tevals[:, k] = mTe[ids, k]
+                            Kevals[:, k] = mKe[ids, k]
+                zavg = numpy.average(zvals, weights=weights, axis=1)
+                cumavg = numpy.average(cumvals, weights=weights, axis=1)
+                humavg = numpy.average(humvals, weights=weights, axis=1)
+                fumavg = numpy.average(fumvals, weights=weights, axis=1)
+                if wcum is not None:
+                    wumavg = numpy.average(wumvals, weights=weights, axis=1)
+                if flexure == 1:
+                    cumfavg = numpy.average(cumfvals, weights=weights, axis=1)
+                if strat == 1:
+                    scumavg = numpy.average(scumvals, weights=weights, axis=1)
+                if ero == 1:
+                    Teavg = numpy.zeros((len(zavg), lay))
+                    Keavg = numpy.zeros((len(zavg), lay))
+                    for k in range(lay):
+                        Teavg[:, k] = numpy.average(Tevals[:, k], weights=weights, axis=1)
+                        Keavg[:, k] = Kevals[indices[0], k]
+                newelev = numpy.concatenate((newelev, zavg), axis=0)
+                newcum = numpy.concatenate((newcum, cumavg), axis=0)
+                newhcum = numpy.concatenate((newhcum, humavg), axis=0)
+                newfcum = numpy.concatenate((newfcum, fumavg), axis=0)
+                if wcum is not None:
+                    newwcum = numpy.concatenate((newwcum, wumavg), axis=0)
+                if flexure == 1:
+                    newcumf = numpy.concatenate((newcumf, cumfavg), axis=0)
+                if strat == 1:
+                    newscum = numpy.concatenate((newscum, scumavg), axis=0)
+                if ero == 1:
+                    newTe = numpy.zeros((len(newelev), lay))
+                    newKe = numpy.zeros((len(newelev), lay))
+                    for k in range(lay):
+                        newTe[:, k] = numpy.concatenate((nTe[:, k], Teavg[:, k]), axis=0)
+                        newKe[:, k] = numpy.concatenate((nKe[:, k], Keavg[:, k]), axis=0)
+            elif len(newTIN["vertices"][:, 0]) < len(newXY):
+                raise ValueError("Problem building the TIN after 3D displacements.")
+
+            if flexure == 0:
+                newcumf = None
+            if strat == 0:
+                newscum = None
+            if ero == 0:
+                newKe = None
+                newTe = None
+            if wcum is None:
+                newwcum = None
+
+            return (
+                newTIN,
+                newelev,
+                newcum,
+                newhcum,
+                newfcum,
+                newwcum,
+                newcumf,
+                newscum,
+                newKe,
+                newTe,
+            )
+
+    def apply_XY_displacements_Carb_vars(self,area,fixIDs,carbMesh):
+        
         """
         Apply horizontal displacements and check if any point needs to be merged.
-
         Args:
             area : float averaged area of the irregular grid delaunay cells.
             fixIDs : integer number of unstructured vertices which needs to stay fix (edges and borders nodes).
-            elev : float numpy array with elevation of previous TIN nodes.
-            tcum : float numpy array with erosion/deposition values from previous TIN nodes.
-            tflex : float numpy array with cumulative flexural values from previous TIN nodes.
-            scum : float numpy array with erosion/deposition used for stratal mesh.
-            hcum : float numpy array with erosion/deposition for hillslope used for stratal mesh.
-            wcum : float numpy array with erosion/deposition for wave used for stratal mesh.
-            Te : float numpy array with thickness used for erosional mesh.
-            Ke : float numpy array with erodibility used for erosional mesh.
-            flexure : integer flagging flexural isostasy.
-            strat : integer flagging stratigraphic mesh model.
-            ero : integer flagging erosional mesh model.
+            carbMesh : carbonate mesh object that contain all carbonate variables
+            """
+        
+        #Initial variables
+        paleodepth_i=np.copy(carbMesh.paleoDepth)
+        depothick_i=np.copy(carbMesh.depoThick)
+        layerthick_i=np.copy(carbMesh.layerThick)
+        tinBase_i=np.copy(carbMesh.tinBase)
 
-        Returns
-        -------
-        tinMesh
-            delaunay mesh generated after displacements.
-        newelev
-            numpy array containing the updated elevation for the new TIN.
-        newcum
-            numpy array containing the updated erosion/deposition values for the new TIN.
-        newhcum
-            numpy array containing the updated erosion/deposition values for hillslope in the new TIN.
-        newwcum
-            numpy array containing the updated erosion/deposition values for wave in the new TIN.
-        newcumf
-            numpy array containing the updated cumulative flexural values for the new TIN.
-        newscum
-            numpy array containing the updated erosion/deposition values used in the stratal mesh.
-        newKe
-            numpy array containing the updated erodibility values for the new TIN.
-        newTe
-            numpy array containing the updated thickness values used in the erosional mesh.
-        """
-
-        # Apply displacements to TIN points (excluding boundary points)
-        telev += self.dispZ
-        tXY = numpy.copy(self.tXY)
+        ct=0
+        
+        tXY0=(carbMesh.tXY)
+        
+        tXY = numpy.copy(tXY0)
         tXY[fixIDs:, 0] += self.dispX[fixIDs:]
         tXY[fixIDs:, 1] += self.dispY[fixIDs:]
 
@@ -774,203 +1007,183 @@ class forceSim:
         maxY = max(tXY[:fixIDs, 1]) - dx
 
         # Find points outside the area
-        xID = numpy.where(
-            numpy.logical_or(tXY[fixIDs:, 0] <= minX, tXY[fixIDs:, 0] >= maxX)
-        )[0]
-        yID = numpy.where(
-            numpy.logical_or(tXY[fixIDs:, 1] <= minY, tXY[fixIDs:, 1] >= maxY)
-        )[0]
+        xID = numpy.where(numpy.logical_or(tXY[fixIDs:, 0] <= minX, tXY[fixIDs:, 0] >= maxX))[0]
+        yID = numpy.where(numpy.logical_or(tXY[fixIDs:, 1] <= minY, tXY[fixIDs:, 1] >= maxY))[0]
         tIDs = numpy.concatenate((xID, yID), axis=0)
         tID = numpy.unique(tIDs)
         tID += fixIDs
-
-        # Delete outside domain points if any
+        
         if len(tID) > 0:
-            self.tXY = numpy.delete(tXY, tID, 0)
-            elev = numpy.delete(telev, tID, 0)
-            cum = numpy.delete(tcum, tID, 0)
-            hum = numpy.delete(hcum, tID, 0)
-            fum = numpy.delete(fcum, tID, 0)
-            if wcum is not None:
-                wum = numpy.delete(wcum, tID, 0)
-            if flexure == 1:
-                cumf = numpy.delete(tflex, tID, 0)
-            if strat == 1:
-                stcum = numpy.delete(scum, tID, 0)
-            if ero == 1:
-                lay = Ke.shape[1]
-                mKe = numpy.zeros((len(cum), lay))
-                mTe = numpy.zeros((len(cum), lay))
-                for k in range(lay):
-                    mKe[:, k] = numpy.delete(Ke[:, k], tID, 0)
-                    mTe[:, k] = numpy.delete(Te[:, k], tID, 0)
+            carbMesh.tXY = numpy.delete(tXY, tID, 0)
         else:
-            self.tXY = numpy.copy(tXY)
-            elev = telev
-            cum = tcum
-            hum = hcum
-            fum = fcum
-            if wcum is not None:
-                wum = hwum
-            if flexure == 1:
-                cumf = tflex
-            if strat == 1:
-                stcum = scum
-            if ero == 1:
-                lay = Ke.shape[1]
-                mKe = Ke
-                mTe = Te
+            carbMesh.tXY = (tXY)
+        
+        for J in range (0,paleodepth_i.shape[1]):
+            # Apply displacements to TIN points (excluding boundary points)
+            
+            #Reset Variables
+            temp_depothick=[]
+            temp_PaleoDepth=None
+            temp_layerthick=None
+            
+            if ct==0:
+                temp_tinBase=np.copy(tinBase_i)
+            temp_PaleoDepth=np.copy(paleodepth_i[:,J])
+            for nc in range(0,np.shape(depothick_i)[2]):
+                temp_depothick.append(np.copy(depothick_i[:,J,nc]))
+            temp_layerthick=np.copy(layerthick_i[:,J])
 
-        # Create KDTree with deformed points and find points which needs to be merged
-        tree = cKDTree(self.tXY)
-        pairs = tree.query_pairs(self.merge3d)
+            # Delete outside domain points if any
+            depothickk=[]
+            if len(tID) > 0:
+                if ct==0:
+                    TinBase = numpy.delete(temp_tinBase, tID, 0)
+                paleodepth  = numpy.delete(temp_PaleoDepth, tID, 0)
+                for i in range (len(temp_depothick)):
+                    depothickk.append(numpy.delete(temp_depothick[i], tID, 0))
+                layerthick = numpy.delete(temp_layerthick, tID, 0)
+                 ############################################
 
-        # For points which require merging define a new point and
-        # interpolate parameters based on merged points
-        if len(pairs) > 0:
-            pairIDs = numpy.array(list(pairs))
-            nonfixIDs = numpy.where(pairIDs[:, 1] >= fixIDs)
-            tXY = numpy.copy(self.tXY)
-            self.tXY = numpy.delete(tXY, pairIDs[nonfixIDs, 1], 0)
-            elev = numpy.delete(elev, pairIDs[nonfixIDs, 1], 0)
-            cum = numpy.delete(cum, pairIDs[nonfixIDs, 1], 0)
-            hum = numpy.delete(hum, pairIDs[nonfixIDs, 1], 0)
-            fum = numpy.delete(fum, pairIDs[nonfixIDs, 1], 0)
-            if wcum is not None:
-                wum = numpy.delete(wum, pairIDs[nonfixIDs, 1], 0)
-            if flexure == 1:
-                cumf = numpy.delete(cumf, pairIDs[nonfixIDs, 1], 0)
-            if strat == 1:
-                stcum = numpy.delete(stcum, pairIDs[nonfixIDs, 1], 0)
+            else:
+                if ct==0:
+                    TinBase = temp_tinBase
+                paleodepth = temp_PaleoDepth
+                for nc in range(0,len(temp_depothick)):
+                    depothickk.append(temp_depothick[nc])
+                layerthick = temp_layerthick
+                ############################################
 
             # Create KDTree with deformed points and find points which needs to be merged
-            tree = cKDTree(self.tXY)
+            if ct==0:
+                tree = cKDTree(carbMesh.tXY)
+                pairs = tree.query_pairs(self.merge3d)
 
-        newXY = self.tXY
-        newelev = elev
-        newcum = cum
-        newhcum = hum
-        newfcum = fum
-        if wcum is not None:
-            newwcum = wum
-        if flexure == 1:
-            newcumf = cumf
-        if strat == 1:
-            newscum = stcum
-        if ero == 1:
-            nKe = mKe
-            nTe = mTe
+            # For points which require merging define a new point and
+            # interpolate parameters based on merged points
+            if len(pairs) > 0:
+                pairIDs = numpy.array(list(pairs))
+                nonfixIDs = numpy.where(pairIDs[:, 1] >= fixIDs)
+                
+                if ct==0:
+                    tXY = numpy.copy(carbMesh.tXY)
+                    carbMesh.tXY = numpy.delete(tXY, pairIDs[nonfixIDs, 1], 0)
+                    TinBase = numpy.delete(TinBase, pairIDs[nonfixIDs, 1], 0)
+                #TinBase = numpy.delete(TinBase, pairIDs[nonfixIDs, 1], 0)
+                paleodepth = numpy.delete(paleodepth, pairIDs[nonfixIDs, 1], 0)
+                for nc in range(0,len(temp_depothick)):
+                    depothickk[nc]= numpy.delete(depothickk[nc],pairIDs[nonfixIDs, 1], 0)
+                layerthick = numpy.delete(layerthick, pairIDs[nonfixIDs, 1], 0)
+                
+                ############################################
 
-        # Based on new points build the triangulation
-        tmpTIN = triangle.triangulate({"vertices": newXY}, "eqDa" + str(area))
-        idsX = numpy.where(
-            numpy.logical_and(
-                tmpTIN["vertices"][:, 0] > minX, tmpTIN["vertices"][:, 0] < maxX
+                # Create KDTree with deformed points and find points which needs to be merged
+                tree = cKDTree(carbMesh.tXY)
+            
+            if ct==0:
+                newXY = carbMesh.tXY
+                newTinBase=TinBase
+
+            newPaleoDepth= paleodepth
+            for nc in range(0,len(temp_depothick)):
+                newdepothick=depothickk
+            newlayerthick= layerthick
+
+            # Based on new points build the triangulation
+            tmpTIN = triangle.triangulate({"vertices": newXY}, "eqDa" + str(area))
+            idsX = numpy.where(
+                numpy.logical_and(
+                    tmpTIN["vertices"][:, 0] > minX, tmpTIN["vertices"][:, 0] < maxX
+                )
             )
-        )
-        idsY = numpy.where(
-            numpy.logical_and(
-                tmpTIN["vertices"][:, 1] > minY, tmpTIN["vertices"][:, 1] < maxY
+            idsY = numpy.where(
+                numpy.logical_and(
+                    tmpTIN["vertices"][:, 1] > minY, tmpTIN["vertices"][:, 1] < maxY
+                )
             )
-        )
-        insID = numpy.intersect1d(idsX, idsY)
-        tmpXY = numpy.zeros((fixIDs + len(insID), 2))
-        tmpXY[:fixIDs, :] = tXY[:fixIDs, :]
-        tmpXY[fixIDs:, :] = tmpTIN["vertices"][insID, :]
-        newTIN = triangle.triangulate({"vertices": tmpXY}, "eDa" + str(area))
+            insID = numpy.intersect1d(idsX, idsY)
+            tmpXY = numpy.zeros((fixIDs + len(insID), 2))
+            tmpXY[:fixIDs, :] = tXY[:fixIDs, :]
+            tmpXY[fixIDs:, :] = tmpTIN["vertices"][insID, :]
+            newTIN = triangle.triangulate({"vertices": tmpXY}, "eDa" + str(area))
 
-        # If some points have been added during the triangulation update the TIN
-        # interpolate neighbouring parameters to these new points
-        if len(newTIN["vertices"][:, 0]) > len(newXY[:, 0]):
-            addPts = newTIN["vertices"][len(newXY[:, 0]) :, :2]
-            dist, ids = tree.query(addPts, k=3)
-            weights = 1.0 / dist ** 2
-            if len(elev[ids].shape) == 3:
-                zvals = elev[ids][:, :, 0]
-                cumvals = cum[ids][:, :, 0]
-                humvals = hum[ids][:, :, 0]
-                fumvals = fum[ids][:, :, 0]
-                if wcum is not None:
-                    wumvals = wum[ids][:, :, 0]
-                if flexure == 1:
-                    cumfvals = cumf[ids][:, :, 0]
-                if strat == 1:
-                    scumvals = stcum[ids][:, :, 0]
-            else:
-                zvals = elev[ids]
-                cumvals = cum[ids]
-                humvals = hum[ids]
-                fumvals = fum[ids]
-                if wcum is not None:
-                    wumvals = wum[ids]
-                if flexure == 1:
-                    cumfvals = cumf[ids]
-                if strat == 1:
-                    scumvals = stcum[ids]
-            if ero == 1:
-                Tevals = numpy.zeros((len(zvals), lay))
-                Kevals = numpy.zeros((len(zvals), lay))
-                for k in range(lay):
-                    if len(mTe[ids, k].shape) == 3:
-                        Tevals[:, k] = mTe[ids, k][:, :, 0]
-                        Kevals[:, k] = mKe[ids, k][:, :, 0]
-                    else:
-                        Tevals[:, k] = mTe[ids, k]
-                        Kevals[:, k] = mKe[ids, k]
-            zavg = numpy.average(zvals, weights=weights, axis=1)
-            cumavg = numpy.average(cumvals, weights=weights, axis=1)
-            humavg = numpy.average(humvals, weights=weights, axis=1)
-            fumavg = numpy.average(fumvals, weights=weights, axis=1)
-            if wcum is not None:
-                wumavg = numpy.average(wumvals, weights=weights, axis=1)
-            if flexure == 1:
-                cumfavg = numpy.average(cumfvals, weights=weights, axis=1)
-            if strat == 1:
-                scumavg = numpy.average(scumvals, weights=weights, axis=1)
-            if ero == 1:
-                Teavg = numpy.zeros((len(zavg), lay))
-                Keavg = numpy.zeros((len(zavg), lay))
-                for k in range(lay):
-                    Teavg[:, k] = numpy.average(Tevals[:, k], weights=weights, axis=1)
-                    Keavg[:, k] = Kevals[indices[0], k]
-            newelev = numpy.concatenate((newelev, zavg), axis=0)
-            newcum = numpy.concatenate((newcum, cumavg), axis=0)
-            newhcum = numpy.concatenate((newhcum, humavg), axis=0)
-            newfcum = numpy.concatenate((newfcum, fumavg), axis=0)
-            if wcum is not None:
-                newwcum = numpy.concatenate((newwcum, wumavg), axis=0)
-            if flexure == 1:
-                newcumf = numpy.concatenate((newcumf, cumfavg), axis=0)
-            if strat == 1:
-                newscum = numpy.concatenate((newscum, scumavg), axis=0)
-            if ero == 1:
-                newTe = numpy.zeros((len(newelev), lay))
-                newKe = numpy.zeros((len(newelev), lay))
-                for k in range(lay):
-                    newTe[:, k] = numpy.concatenate((nTe[:, k], Teavg[:, k]), axis=0)
-                    newKe[:, k] = numpy.concatenate((nKe[:, k], Keavg[:, k]), axis=0)
-        elif len(newTIN["vertices"][:, 0]) < len(newXY):
-            raise ValueError("Problem building the TIN after 3D displacements.")
+            # If some points have been added during the triangulation update the TIN
+            # interpolate neighbouring parameters to these new points
+            if len(newTIN["vertices"][:, 0]) > len(newXY[:, 0]):
+                addPts = newTIN["vertices"][len(newXY[:, 0]) :, :2]
+                dist, ids = tree.query(addPts, k=3)
+                weights = 1.0 / dist ** 2
+                
+                depothickk_vals=[]
+                
+                if len(layerthick[ids].shape) == 3:
+                    print("3D - Remeshing Carb stratigraphic history")
+                    #######################################
+                    ### Carbonate case
+                    if ct==0:
+                        TinBase_vals = TinBase[ids][:, :, 0]
+                    paleodepth_vals = paleodepth[ids][:, :, 0]
+                    for nc in range(0,len(temp_depothick)):
+                        depothickk_vals.append(depothickk[nc][ids][:, :, 0])
+                    layerthick_vals = layerthick[ids][:, :, 0]
+                    #####################################
+                else:
+                    
+                    print("2D - Remeshing Carb stratigraphic history")
+        #             ####################################
+                    ### Carbonate case
+                    if ct==0:
+                        TinBase_vals = TinBase[ids]
+                    
+                    paleodepth_vals = paleodepth[ids]
+                    for nc in range(0,len(temp_depothick)):
+                        depothickk_vals.append(depothickk[nc][ids])
+                    layerthick_vals = layerthick[ids]
 
-        if flexure == 0:
-            newcumf = None
-        if strat == 0:
-            newscum = None
-        if ero == 0:
-            newKe = None
-            newTe = None
-        if wcum is None:
-            newwcum = None
+                    #####################################
+                ####################################################
+                #Average carbonate mesh variables
+                if ct==0:
+                    TinBase_avg = numpy.average(TinBase_vals, weights=weights, axis=1)
+                depothickk_avg=[]
+                
+                paleodepth_avg= numpy.average(paleodepth_vals, weights=weights, axis=1)
+                for nc in range(0,len(temp_depothick)):
+                    depothickk_avg.append(numpy.average(depothickk_vals[nc], weights=weights, axis=1))
+                layerthick_avg= numpy.average(layerthick_vals, weights=weights, axis=1)
+                
+                ####################################################
+                #New Carbonate variables computation
+                if ct==0:
+                    newTinBase = numpy.concatenate((newTinBase,TinBase_avg), axis=0)
+                newPaleoDepth= numpy.concatenate((newPaleoDepth,paleodepth_avg), axis=0)
+                for nc in range(0,len(temp_depothick)):
+                    newdepothick[nc]=numpy.concatenate((newdepothick[nc],depothickk_avg[nc]), axis=0)
+                newlayerthick= numpy.concatenate((newlayerthick,layerthick_avg), axis=0)
+                ####################################################
+            elif len(newTIN["vertices"][:, 0]) < len(newXY):
+                raise ValueError("Problem building the TIN after 3D displacements.")
+            
+            if ct==0:
+                #deformed TIN mesh after horizontal displacements. This regrids the carb strata variables at all time steps.
+                def_PaleoDepth=np.zeros((len(newPaleoDepth),np.shape(paleodepth_i)[1]),order='F')
+                def_depothick=np.zeros((len(newPaleoDepth),np.shape(depothick_i)[1],np.shape(depothick_i)[2]),order='F')
+                def_layerthick=np.zeros((len(newPaleoDepth),np.shape(layerthick_i)[1]),order='F')
 
-        return (
-            newTIN,
-            newelev,
-            newcum,
-            newhcum,
-            newfcum,
-            newwcum,
-            newcumf,
-            newscum,
-            newKe,
-            newTe,
-        )
+            def_PaleoDepth[:,J]=newPaleoDepth
+            for nc in range(0,len(temp_depothick)):
+                def_depothick[:,J,nc]=newdepothick[nc]
+            def_layerthick[:,J]=newlayerthick
+            
+            ct=ct+1
+            
+            #This avoids to re-mesh the entire array, which is full of zeros
+            if carbMesh.step + 2 == ct:
+                break
+        
+        carbMesh.tinBase=newTinBase
+        carbMesh.paleoDepth= def_PaleoDepth
+        carbMesh.depoThick= def_depothick
+        carbMesh.layerThick= def_layerthick
+
+
+        return 1

--- a/badlands/badlands/forcing/forceSim.py
+++ b/badlands/badlands/forcing/forceSim.py
@@ -702,7 +702,8 @@ class forceSim:
             return update, sdispX, sdispY
         else:
             return update
-
+    
+    
     def apply_XY_displacements(
             self,
             area,
@@ -764,6 +765,11 @@ class forceSim:
             tXY[fixIDs:, 0] += self.dispX[fixIDs:]
             tXY[fixIDs:, 1] += self.dispY[fixIDs:]
 
+            ##Detects wave module
+            #if wcum is not None:
+            meanH_i=numpy.copy(self.meanH)
+            meanS_i=numpy.copy(self.meanS)
+
             # Specify inside simulation area parameters
             dx = tXY[1, 0] - tXY[0, 0]
             minX = min(tXY[:fixIDs, 0]) + dx
@@ -791,6 +797,9 @@ class forceSim:
                 fum = numpy.delete(fcum, tID, 0)
                 if wcum is not None:
                     wum = numpy.delete(wcum, tID, 0)
+                    if self.meanH is not None and self.meanS is not None:
+                        meanH = numpy.delete(meanH_i, tID, 0)
+                        meanS = numpy.delete(meanS_i, tID, 0)
                 if flexure == 1:
                     cumf = numpy.delete(tflex, tID, 0)
                 if strat == 1:
@@ -812,6 +821,9 @@ class forceSim:
                     ##### THERE WAS A TYPO HERE....
                     wum = wcum
                     #############
+                    if self.meanH is not None and self.meanS is not None:
+                        meanH = meanH_i
+                        meanS = meanS_i
                 if flexure == 1:
                     cumf = tflex
                 if strat == 1:
@@ -838,6 +850,9 @@ class forceSim:
                 fum = numpy.delete(fum, pairIDs[nonfixIDs, 1], 0)
                 if wcum is not None:
                     wum = numpy.delete(wum, pairIDs[nonfixIDs, 1], 0)
+                    if self.meanH is not None and self.meanS is not None:
+                        meanH = numpy.delete(meanH, pairIDs[nonfixIDs, 1], 0)
+                        meanS = numpy.delete(meanS, pairIDs[nonfixIDs, 1], 0)
                 if flexure == 1:
                     cumf = numpy.delete(cumf, pairIDs[nonfixIDs, 1], 0)
                 if strat == 1:
@@ -853,6 +868,9 @@ class forceSim:
             newfcum = fum
             if wcum is not None:
                 newwcum = wum
+                if self.meanH is not None and self.meanS is not None:
+                    new_meanH = meanH
+                    new_meanS = meanS
             if flexure == 1:
                 newcumf = cumf
             if strat == 1:
@@ -892,6 +910,9 @@ class forceSim:
                     fumvals = fum[ids][:, :, 0]
                     if wcum is not None:
                         wumvals = wum[ids][:, :, 0]
+                        if self.meanH is not None and self.meanS is not None:
+                            meanH_vals = meanH[ids][:, :, 0]
+                            meanS_vals = meanS[ids][:, :, 0]
                     if flexure == 1:
                         cumfvals = cumf[ids][:, :, 0]
                     if strat == 1:
@@ -903,6 +924,9 @@ class forceSim:
                     fumvals = fum[ids]
                     if wcum is not None:
                         wumvals = wum[ids]
+                        if self.meanH is not None and self.meanS is not None:
+                            meanH_vals = meanH[ids]
+                            meanS_vals = meanS[ids]
                     if flexure == 1:
                         cumfvals = cumf[ids]
                     if strat == 1:
@@ -923,6 +947,9 @@ class forceSim:
                 fumavg = numpy.average(fumvals, weights=weights, axis=1)
                 if wcum is not None:
                     wumavg = numpy.average(wumvals, weights=weights, axis=1)
+                    if self.meanH is not None and self.meanS is not None:
+                        meanH_avg = numpy.average(meanH_vals, weights=weights, axis=1)
+                        meanS_avg = numpy.average(meanS_vals, weights=weights, axis=1)
                 if flexure == 1:
                     cumfavg = numpy.average(cumfvals, weights=weights, axis=1)
                 if strat == 1:
@@ -939,6 +966,9 @@ class forceSim:
                 newfcum = numpy.concatenate((newfcum, fumavg), axis=0)
                 if wcum is not None:
                     newwcum = numpy.concatenate((newwcum, wumavg), axis=0)
+                    if self.meanH is not None and self.meanS is not None:
+                        new_meanH = numpy.concatenate((new_meanH, meanH_avg), axis=0)
+                        new_meanS = numpy.concatenate((new_meanS, meanS_avg), axis=0)
                 if flexure == 1:
                     newcumf = numpy.concatenate((newcumf, cumfavg), axis=0)
                 if strat == 1:
@@ -961,6 +991,12 @@ class forceSim:
                 newTe = None
             if wcum is None:
                 newwcum = None
+                new_meanH = None
+                new_meanS = None
+
+            if wcum is not None and self.meanH is not None and self.meanS is not None:
+                self.meanH = new_meanH
+                self.meanS = new_meanS
 
             return (
                 newTIN,
@@ -974,7 +1010,7 @@ class forceSim:
                 newKe,
                 newTe,
             )
-
+    
     def apply_XY_displacements_Carb_vars(self,area,fixIDs,carbMesh):
         
         """
@@ -986,10 +1022,10 @@ class forceSim:
             """
         
         #Initial variables
-        paleodepth_i=np.copy(carbMesh.paleoDepth)
-        depothick_i=np.copy(carbMesh.depoThick)
-        layerthick_i=np.copy(carbMesh.layerThick)
-        tinBase_i=np.copy(carbMesh.tinBase)
+        paleodepth_i=numpy.copy(carbMesh.paleoDepth)
+        depothick_i=numpy.copy(carbMesh.depoThick)
+        layerthick_i=numpy.copy(carbMesh.layerThick)
+        tinBase_i=numpy.copy(carbMesh.tinBase)
 
         ct=0
         
@@ -1027,11 +1063,11 @@ class forceSim:
             temp_layerthick=None
             
             if ct==0:
-                temp_tinBase=np.copy(tinBase_i)
-            temp_PaleoDepth=np.copy(paleodepth_i[:,J])
-            for nc in range(0,np.shape(depothick_i)[2]):
-                temp_depothick.append(np.copy(depothick_i[:,J,nc]))
-            temp_layerthick=np.copy(layerthick_i[:,J])
+                temp_tinBase=numpy.copy(tinBase_i)
+            temp_PaleoDepth=numpy.copy(paleodepth_i[:,J])
+            for nc in range(0,numpy.shape(depothick_i)[2]):
+                temp_depothick.append(numpy.copy(depothick_i[:,J,nc]))
+            temp_layerthick=numpy.copy(layerthick_i[:,J])
 
             # Delete outside domain points if any
             depothickk=[]
@@ -1068,7 +1104,6 @@ class forceSim:
                     tXY = numpy.copy(carbMesh.tXY)
                     carbMesh.tXY = numpy.delete(tXY, pairIDs[nonfixIDs, 1], 0)
                     TinBase = numpy.delete(TinBase, pairIDs[nonfixIDs, 1], 0)
-                #TinBase = numpy.delete(TinBase, pairIDs[nonfixIDs, 1], 0)
                 paleodepth = numpy.delete(paleodepth, pairIDs[nonfixIDs, 1], 0)
                 for nc in range(0,len(temp_depothick)):
                     depothickk[nc]= numpy.delete(depothickk[nc],pairIDs[nonfixIDs, 1], 0)
@@ -1128,7 +1163,7 @@ class forceSim:
                     #####################################
                 else:
                     
-                    print("2D - Remeshing Carb stratigraphic history")
+                    #print("Remeshing Carb stratigraphic history")
         #             ####################################
                     ### Carbonate case
                     if ct==0:
@@ -1165,9 +1200,9 @@ class forceSim:
             
             if ct==0:
                 #deformed TIN mesh after horizontal displacements. This regrids the carb strata variables at all time steps.
-                def_PaleoDepth=np.zeros((len(newPaleoDepth),np.shape(paleodepth_i)[1]),order='F')
-                def_depothick=np.zeros((len(newPaleoDepth),np.shape(depothick_i)[1],np.shape(depothick_i)[2]),order='F')
-                def_layerthick=np.zeros((len(newPaleoDepth),np.shape(layerthick_i)[1]),order='F')
+                def_PaleoDepth=numpy.zeros((len(newPaleoDepth),numpy.shape(paleodepth_i)[1]),order='F')
+                def_depothick=numpy.zeros((len(newPaleoDepth),numpy.shape(depothick_i)[1],numpy.shape(depothick_i)[2]),order='F')
+                def_layerthick=numpy.zeros((len(newPaleoDepth),numpy.shape(layerthick_i)[1]),order='F')
 
             def_PaleoDepth[:,J]=newPaleoDepth
             for nc in range(0,len(temp_depothick)):
@@ -1187,3 +1222,5 @@ class forceSim:
 
 
         return 1
+
+    

--- a/badlands/badlands/model.py
+++ b/badlands/badlands/model.py
@@ -571,19 +571,7 @@ class Model(object):
                             self.fixIDs,
                             self.carbTIN,
                             )
-                        ######################################################################
-                        
-                        ######################################################################
-                        # THIS FUNCTION REMESHES THE wave forcing variables
-                        # BASED ON THE APPLY_XY_DISPLACEMENTS USED FOR THE TIN VARIABLES 
-#                         if self.input.waveSed and self.force.meanH is not None and self.force.meanS is not None:
-#                             (WaveF_xyx) = self.force.apply_XY_displacements_waveForcing(
-#                             self.recGrid.areaDel,
-#                             self.fixIDs,
-#                             )
-                        ######################################################################
-                        
-                        
+                        ######################################################################                       
                         
                         # Update relevant parameters in deformed TIN
                         if fflex == 1:

--- a/badlands/badlands/simulation/buildMesh.py
+++ b/badlands/badlands/simulation/buildMesh.py
@@ -31,19 +31,16 @@ if "READTHEDOCS" not in os.environ:
     )
 
 
-def construct_mesh(input, filename, verbose=False):
+def construct_mesh(input, filename,UwFlag=False, verbose=False):
     """
     The following function is taking parsed values from the XML to:
-
     * build model grids & meshes,
     * initialise Finite Volume discretisation,
     * define the partitioning when parallelisation is enable.
-
     Args:
         input: class containing XML input file parameters.
         filename: (str) this is a string containing the path to the regular grid file.
         verbose : (bool) when :code:`True`, output additional debug information (default: :code:`False`).
-
     Returns
     -------
     recGrid
@@ -176,11 +173,11 @@ def construct_mesh(input, filename, verbose=False):
             cumflex,
             inIDs,
             parentIDs,
-        ) = _define_TINparams(
+        ) = buildMesh._define_TINparams(
             totPts, lGIDs[recGrid.boundsPt :], input, FVmesh, recGrid, verbose
         )
     else:
-        elevation, cumdiff, cumhill, cumfail, inIDs, parentIDs = _define_TINparams(
+        elevation, cumdiff, cumhill, cumfail, inIDs, parentIDs = buildMesh._define_TINparams(
             totPts, lGIDs[recGrid.boundsPt :], input, FVmesh, recGrid, verbose
         )
 
@@ -280,6 +277,16 @@ def construct_mesh(input, filename, verbose=False):
                 input.rfolder,
                 input.rstep,
             )
+            
+            if UwFlag == True:
+                #After the carbonate meshs is created we need to re-shape the variables loaded from the restart step to match the size of the local mesh.
+                erolay_big=int(input.tEnd/input.tDisplay)+3
+                print("Re-Meshing Carbonate variables - Re-Start")
+                (carbTIN.paleoDepth,
+                carbTIN.depoThick,
+                carbTIN.layerThick) = buildMesh.load_hdf5_carbM(input.rfolder, input.rstep, carbTIN.tXY,nbSed,erolay_big)
+            
+            
         else:
             carbTIN = carbMesh.carbMesh(
                 layNb,
@@ -322,6 +329,7 @@ def construct_mesh(input, filename, verbose=False):
         straTIN,
         carbTIN,
     )
+
 
 
 def reconstruct_mesh(recGrid, input, verbose=False):

--- a/badlands/badlands/simulation/buildMesh.py
+++ b/badlands/badlands/simulation/buildMesh.py
@@ -31,7 +31,7 @@ if "READTHEDOCS" not in os.environ:
     )
 
 
-def construct_mesh(input, filename,UwFlag=False, verbose=False):
+def construct_mesh(input, filename,DispX_Flag=False, verbose=False):
     """
     The following function is taking parsed values from the XML to:
     * build model grids & meshes,
@@ -173,11 +173,11 @@ def construct_mesh(input, filename,UwFlag=False, verbose=False):
             cumflex,
             inIDs,
             parentIDs,
-        ) = buildMesh._define_TINparams(
+        ) = _define_TINparams(
             totPts, lGIDs[recGrid.boundsPt :], input, FVmesh, recGrid, verbose
         )
     else:
-        elevation, cumdiff, cumhill, cumfail, inIDs, parentIDs = buildMesh._define_TINparams(
+        elevation, cumdiff, cumhill, cumfail, inIDs, parentIDs = _define_TINparams(
             totPts, lGIDs[recGrid.boundsPt :], input, FVmesh, recGrid, verbose
         )
 
@@ -260,6 +260,12 @@ def construct_mesh(input, filename,UwFlag=False, verbose=False):
             nbSed = 2
 
         if input.restart:
+            #The carbonate variables numpy arrays must have size of all the time steps of the simulation
+            #otherwise, the error "Broadcasting is not supported for complex selections" is raised
+            layNb = int((input.tEnd - input.tStart) / input.tDisplay) + 3
+            
+            #erolay_big=int(input.tEnd/input.tDisplay)+3     
+            
             carbTIN = carbMesh.carbMesh(
                 layNb,
                 input.initlayers,
@@ -276,15 +282,16 @@ def construct_mesh(input, filename,UwFlag=False, verbose=False):
                 elevation,
                 input.rfolder,
                 input.rstep,
+                DispX_Flag=DispX_Flag,
             )
             
-            if UwFlag == True:
+            if DispX_Flag == True:
                 #After the carbonate meshs is created we need to re-shape the variables loaded from the restart step to match the size of the local mesh.
-                erolay_big=int(input.tEnd/input.tDisplay)+3
-                print("Re-Meshing Carbonate variables - Re-Start")
+                
+                #print("Re-Meshing Carbonate variables - Re-Start")
                 (carbTIN.paleoDepth,
                 carbTIN.depoThick,
-                carbTIN.layerThick) = buildMesh.load_hdf5_carbM(input.rfolder, input.rstep, carbTIN.tXY,nbSed,erolay_big)
+                carbTIN.layerThick) = recGrid.load_hdf5_carbM(input.rfolder, input.rstep, carbTIN.tXY,nbSed,layNb)
             
             
         else:

--- a/badlands/badlands/simulation/checkPoints.py
+++ b/badlands/badlands/simulation/checkPoints.py
@@ -148,12 +148,18 @@ def write_checkpoints(
     rockOn = False
     if input.carbonate:
         rockOn = True
+    else:
+        rockOn = False
         
     if input.carbonate2:
         carb2On = True
+    else:
+        carb2On = False
         
     if input.pelagic:
         pelagicOn = True
+    else:
+        pelagicOn = False
     ######################################################################
         
         
@@ -207,7 +213,7 @@ def write_checkpoints(
     # NEW PELAGIC FIELD
     #############################################################
     elif input.pelagic:
-        write_hdf5_pelagic(
+        visualiseTIN.write_hdf5_pelagic(
             input.outDir,
             input.th5file,
             step,
@@ -324,7 +330,7 @@ def write_checkpoints(
             )
 
     # Combine HDF5 files and write time series
-    write_xmf(
+    visualiseTIN.write_xmf(
         input.outDir,
         input.txmffile,
         input.txdmffile,

--- a/badlands/badlands/simulation/checkPoints.py
+++ b/badlands/badlands/simulation/checkPoints.py
@@ -40,6 +40,7 @@ if "READTHEDOCS" not in os.environ:
     from badlands import visualiseFlow, visualiseTIN, eroMesh
 
 
+
 def write_checkpoints(
     input,
     recGrid,
@@ -63,7 +64,6 @@ def write_checkpoints(
 ):
     """
     Create the checkpoint files (used for HDF5 output).
-
     Args:
         input: class containing XML input file parameters.
         recGrid: class describing the regular grid characteristics.
@@ -143,13 +143,27 @@ def write_checkpoints(
         flow.basinID[seaIDs] = -1
     visdis[visdis < 1.0] = 1.0
 
+    ########################################################################
+    # The pelagic rain is now another "Rock"
     rockOn = False
-    if input.carbonate or input.pelagic:
+    if input.carbonate:
         rockOn = True
-
+        
+    if input.carbonate2:
+        carb2On = True
+        
+    if input.pelagic:
+        pelagicOn = True
+    ######################################################################
+        
+        
     # Write HDF5 files
     if input.waveSed and tNow > input.tStart:
         waveOn = True
+        ######################################################################
+        #print("wave bug- re start")
+        #print(len(lGIDs),len(force.meanH))
+        ######################################################################
         meanH = force.meanH[lGIDs]
         meanS = force.meanS[lGIDs]
         wdiff = wavediff[lGIDs]
@@ -159,6 +173,9 @@ def write_checkpoints(
         meanS = None
         wdiff = None
 
+    
+    
+    
     if input.flexure:
         visualiseTIN.write_hdf5_flexure(
             input.outDir,
@@ -186,6 +203,38 @@ def write_checkpoints(
             prop[lGIDs, :],
             force.sealevel,
         )
+    #############################################################
+    # NEW PELAGIC FIELD
+    #############################################################
+    elif input.pelagic:
+        write_hdf5_pelagic(
+            input.outDir,
+            input.th5file,
+            step,
+            FVmesh.node_coords[:, :2],
+            elevation[lGIDs],
+            fillH[lGIDs],
+            rain[lGIDs],
+            visdis[lGIDs],
+            cumdiff[lGIDs],
+            cumhill[lGIDs],
+            cumfail[lGIDs],
+            FVmesh.outCells,
+            input.oroRain,
+            eroOn,
+            flow.erodibility[lGIDs],
+            FVmesh.control_volumes[lGIDs],
+            waveOn,
+            meanH,
+            meanS,
+            wdiff,
+            rockOn,
+            pelagicOn,
+            carb2On,
+            prop[lGIDs, :],
+            force.sealevel,
+        )
+    #############################################################
     else:
         visualiseTIN.write_hdf5(
             input.outDir,
@@ -275,7 +324,7 @@ def write_checkpoints(
             )
 
     # Combine HDF5 files and write time series
-    visualiseTIN.write_xmf(
+    write_xmf(
         input.outDir,
         input.txmffile,
         input.txdmffile,

--- a/badlands/badlands/surface/raster2TIN.py
+++ b/badlands/badlands/surface/raster2TIN.py
@@ -432,7 +432,7 @@ class raster2TIN:
 
         return elev, cum, hcum, scum, fcum
 
-    def load_hdf5_carbM(restartFolder, timestep, tXY,nbSed,erolay_big):
+    def load_hdf5_carbM(self,restartFolder, timestep, tXY,nbSed,erolay_big):
         """
         This function reads and allocates **badlands** carbonate parameters & variables from a previous
         simulation. These parameters are obtained from a specific time HDF5 file.
@@ -492,7 +492,7 @@ class raster2TIN:
         eroLay1 =  paleoDepth_i.shape[1]
         eroLay =  erolay_big
         #maybe erolay + 1? does the trick
-        depoThicks_i = np.zeros((paleoDepth_i.shape[0],eroLay,nbSed)) #Shape in second row is always time step + 1. The 0 also counts!!
+        depoThicks_i = numpy.zeros((paleoDepth_i.shape[0],eroLay,nbSed)) #Shape in second row is always time step + 1. The 0 also counts!!
 
         
         for r in range(nbSed-1):
@@ -502,7 +502,7 @@ class raster2TIN:
 
        ###################################################################################################
         ct=0
-        for J in range (0,np.shape(paleoDepth_i )[1]):
+        for J in range (0,numpy.shape(paleoDepth_i )[1]):
         # Apply displacements to TIN points (excluding boundary points)
 
             #Reset Variables
@@ -510,11 +510,11 @@ class raster2TIN:
             temp_PaleoDepth=None
             temp_layerthick=None
 
-            temp_PaleoDepth=np.copy(paleoDepth_i[:,J])
+            temp_PaleoDepth=numpy.copy(paleoDepth_i[:,J])
             for nc in range(0,nbSed-1):
-                temp_depothick.append(np.copy(depoThicks_i[:,J,nc]))
+                temp_depothick.append(numpy.copy(depoThicks_i[:,J,nc]))
                 
-            temp_layerthick=np.copy(layerThick_i[:,J])
+            temp_layerthick=numpy.copy(layerThick_i[:,J])
 
        ###################################################################################################
 
@@ -562,7 +562,7 @@ class raster2TIN:
                     layerThick_f[onIDs]= temp_layerthick[indices[onIDs, 0]]
                     depoThicks_f=[]
                     
-                    depoThick_aux=np.copy(paleoDepth_f)
+                    depoThick_aux=numpy.copy(paleoDepth_f)
                     for nc in range(0,nbSed-1):
 
                         depoThicks_f.append(depoThick_aux)
@@ -571,9 +571,9 @@ class raster2TIN:
             ### THE NUMPY ARRAYS WITH THE RE-MESHED DATA ARE CREATED JUST ONCE
             if ct==0:
                 #deformed TIN mesh after horizontal displacements. This regrids the carb strata variables at all time steps.
-                res_PaleoDepth=np.zeros((len(paleoDepth_f),eroLay),order='F')
-                res_depothick=np.zeros((len(paleoDepth_f),eroLay,nbSed),order='F')
-                res_layerthick=np.zeros((len(paleoDepth_f),eroLay),order='F')
+                res_PaleoDepth=numpy.zeros((len(paleoDepth_f),eroLay),order='F')
+                res_depothick=numpy.zeros((len(paleoDepth_f),eroLay,nbSed),order='F')
+                res_layerthick=numpy.zeros((len(paleoDepth_f),eroLay),order='F')
                 
             res_PaleoDepth[:,J]=paleoDepth_f
             res_layerthick[:,J]=layerThick_f

--- a/badlands/badlands/surface/raster2TIN.py
+++ b/badlands/badlands/surface/raster2TIN.py
@@ -431,3 +431,156 @@ class raster2TIN:
                 fcum[onIDs] = f[indices[onIDs, 0]]
 
         return elev, cum, hcum, scum, fcum
+
+    def load_hdf5_carbM(restartFolder, timestep, tXY,nbSed,erolay_big):
+        """
+        This function reads and allocates **badlands** carbonate parameters & variables from a previous
+        simulation. These parameters are obtained from a specific time HDF5 file.
+        Important:
+            This function is only called when a **restart simulation** is ran... |:bomb:|
+        Args:
+            restartFolder: restart folder name as defined in tge XML input file.
+            timestep: time step to load defined based on output interval number.
+            tXY: 2D numpy array TIN grid local coordinates.
+            nbSed: The number of carbonate variables
+            erolay_big: the number of time steps the model will have according to the UW script and Bdls xml file
+        Returns
+        -------
+        res_PaleoDepth
+            numpy array containing the updated PaleoDepth carbonate variable from the restart model and all time steps.
+        res_depothick
+            numpy array containing the updated PaleoDepth carbonate variable from the restart model and all time steps.
+        res_layerthick
+            numpy array containing the updated PaleoDepth carbonate variable from the restart model and all time steps.
+        """
+        
+        if os.path.exists(restartFolder):
+            folder = restartFolder + "/h5/"
+            fileCPU = "tin.time%s.hdf5" % timestep
+            restartncpus = len(glob.glob1(folder, fileCPU))
+            if restartncpus == 0:
+                raise ValueError(
+                    "The requested time step for the restart simulation cannot be found in the restart folder."
+                )
+        else:
+            raise ValueError(
+                "The restart folder is missing or the given path is incorrect."
+            )
+
+        df = h5py.File("%s/h5/tin.time%s.hdf5" % (restartFolder, timestep), "r")
+        coords = numpy.array((df["/coords"]))
+
+        x, y, z = numpy.hsplit(coords, 3)
+
+        XY = numpy.column_stack((x, y))
+        tree = cKDTree(XY)
+        distances, indices = tree.query(tXY, k=3)
+        ########################################################################################################
+        ###### INTERPOLATE CARBONATE DATA TO THE INITIAL SHAPE
+        if os.path.exists(restartFolder):
+            folderC = restartFolder+'/h5/'
+            fileCPUC = 'stratal.time%s.hdf5' % timestep
+            restartncpusC = len(glob.glob1(folderC,fileCPUC))
+            if restartncpusC == 0:
+                raise ValueError('The requested time step for the restart simulation cannot be found in the restart folder.')
+        else:
+            raise ValueError('The restart folder is missing or the given path is incorrect.')
+
+        dfC = h5py.File('%s/h5/stratal.time%s.hdf5' % (restartFolder, timestep), 'r')
+
+        paleoDepth_i = numpy.array((dfC['/paleoDepth']))
+        eroLay1 =  paleoDepth_i.shape[1]
+        eroLay =  erolay_big
+        #maybe erolay + 1? does the trick
+        depoThicks_i = np.zeros((paleoDepth_i.shape[0],eroLay,nbSed)) #Shape in second row is always time step + 1. The 0 also counts!!
+
+        
+        for r in range(nbSed-1):
+            depoThicks_i[:,:eroLay1,r]=numpy.array((dfC['/depoThickRock'+str(r)]))
+
+        layerThick_i= numpy.sum(depoThicks_i[:,:eroLay,:],axis=-1)
+
+       ###################################################################################################
+        ct=0
+        for J in range (0,np.shape(paleoDepth_i )[1]):
+        # Apply displacements to TIN points (excluding boundary points)
+
+            #Reset Variables
+            temp_depothick=[]
+            temp_PaleoDepth=None
+            temp_layerthick=None
+
+            temp_PaleoDepth=np.copy(paleoDepth_i[:,J])
+            for nc in range(0,nbSed-1):
+                temp_depothick.append(np.copy(depoThicks_i[:,J,nc]))
+                
+            temp_layerthick=np.copy(layerThick_i[:,J])
+
+       ###################################################################################################
+
+            if len(temp_PaleoDepth[indices].shape) == 3:
+                paleoDepth_vals=temp_PaleoDepth[indices][:, :, 0]
+
+                depoThicks_vals=[]
+                for nc in range(0,nbSed-1):
+                    depoThicks_vals.append(temp_depothick[nc][indices][:, :, 0])
+
+                layerThick_vals=temp_layerthick[indices][:, :, 0]
+
+            else:
+                paleoDepth_vals=temp_PaleoDepth[indices]
+
+                depoThicks_vals=[]
+                for nc in range(0,nbSed-1):
+                    depoThicks_vals.append(temp_depothick[nc][indices])
+                    
+                layerThick_vals=temp_layerthick[indices]
+
+
+            with numpy.errstate(divide="ignore"):
+
+                paleoDepth_f=numpy.average(paleoDepth_vals, weights=(1.0 / distances), axis=1)
+                layerThick_f=numpy.average(layerThick_vals, weights=(1.0 / distances), axis=1)
+                
+                depoThicks_f=[]
+                for nc in range(0,nbSed-1):
+                    depoThicks_f.append(numpy.average(depoThicks_vals[nc], weights=(1.0 / distances), axis=1))
+
+            onIDs = numpy.where(distances[:, 0] == 0)[0]
+            if len(onIDs) > 0:
+                if len(temp_PaleoDepth[indices].shape) == 3:
+                    paleoDepth_f[onIDs]= temp_PaleoDepth[indices[onIDs, 0], 0]
+                    layerThick_f[onIDs]= temp_layerthick[indices[onIDs, 0], 0]
+                    depoThicks_f=[]
+                    
+                    for nc in range(0,nbSed-1):
+                        depoThick_aux=temp_depothick[nc][indices[onIDs, 0], 0]
+                        depoThicks_f.append(depoThick_aux)
+
+                else:
+                    paleoDepth_f[onIDs]= temp_PaleoDepth[indices[onIDs, 0]]
+                    layerThick_f[onIDs]= temp_layerthick[indices[onIDs, 0]]
+                    depoThicks_f=[]
+                    
+                    depoThick_aux=np.copy(paleoDepth_f)
+                    for nc in range(0,nbSed-1):
+
+                        depoThicks_f.append(depoThick_aux)
+
+            ########################################################################################################
+            ### THE NUMPY ARRAYS WITH THE RE-MESHED DATA ARE CREATED JUST ONCE
+            if ct==0:
+                #deformed TIN mesh after horizontal displacements. This regrids the carb strata variables at all time steps.
+                res_PaleoDepth=np.zeros((len(paleoDepth_f),eroLay),order='F')
+                res_depothick=np.zeros((len(paleoDepth_f),eroLay,nbSed),order='F')
+                res_layerthick=np.zeros((len(paleoDepth_f),eroLay),order='F')
+                
+            res_PaleoDepth[:,J]=paleoDepth_f
+            res_layerthick[:,J]=layerThick_f
+            
+            for nc in range(0,nbSed-1):
+                res_depothick[:,J,nc]=depoThicks_f[nc]
+            
+            ct=ct+1
+
+        return res_PaleoDepth, res_depothick, res_layerthick

--- a/badlands/badlands/surface/visualiseTIN.py
+++ b/badlands/badlands/surface/visualiseTIN.py
@@ -850,4 +850,4 @@ def write_xmf(
     _write_xdmf(folder, xdmffile, xmffile, step)
 
     return
-    return
+

--- a/badlands/badlands/underland/carbMesh.py
+++ b/badlands/badlands/underland/carbMesh.py
@@ -81,9 +81,12 @@ class carbMesh():
                         raise ValueError('The requested time step for the restart simulation cannot be found in the restart folder.')
                 else:
                     raise ValueError('The restart folder is missing or the given path is incorrect.')
-
+                
+                ###################################################################################################
+                ### I had to comment this line. Is this important Tristan? for making the re-start work?
 #                 if restartncpus != size:
 #                     raise ValueError('When using the stratal model you need to run the restart simulation with the same number of processors as the previous one.')
+                ###################################################################################################
 
                 df = h5py.File('%s/h5/stratal.time%s.hdf5'%(rfolder, rstep), 'r')
 
@@ -131,7 +134,7 @@ class carbMesh():
 
                 # Elevation at time of deposition (paleo-depth)
                 #We instead initialize the self.paleoDepth and etc.. using the actual shape of the loaded array.
-                #This is a numpy array filled with zeros aniway.
+                #This is a numpy array filled with zeros anyway.
                 self.paleoDepth =  numpy.zeros(numpy.shape(paleoDepth),order='F')
                 self.layerThick =  numpy.zeros(numpy.shape(paleoDepth),order='F')
 

--- a/badlands/badlands/underland/carbMesh.py
+++ b/badlands/badlands/underland/carbMesh.py
@@ -47,7 +47,7 @@ class carbMesh():
     """
 
     def __init__(self, layNb, elay, xyTIN, bPts, ePts, thickMap, folder, h5file, baseMap, nbSed,
-                 regX, regY, elev, rfolder=None, rstep=0 ,UwFlag=None):
+                 regX, regY, elev, rfolder=None, rstep=0 ,DispX_Flag=None):
 
         # Number of points on the TIN
         self.ptsNb = len(xyTIN)
@@ -69,8 +69,9 @@ class carbMesh():
         # In case we restart a simulation
         if rstep > 0:
 
-            if UwFlag==False:
-                # Version for not Uw coupling case
+            if DispX_Flag==False:
+                print("No 3D disp- case")
+                # Version for not 3D displacements
             
                 if os.path.exists(rfolder):
                     folder = rfolder+'/h5/'
@@ -81,8 +82,8 @@ class carbMesh():
                 else:
                     raise ValueError('The restart folder is missing or the given path is incorrect.')
 
-                if restartncpus != size:
-                    raise ValueError('When using the stratal model you need to run the restart simulation with the same number of processors as the previous one.')
+#                 if restartncpus != size:
+#                     raise ValueError('When using the stratal model you need to run the restart simulation with the same number of processors as the previous one.')
 
                 df = h5py.File('%s/h5/stratal.time%s.hdf5'%(rfolder, rstep), 'r')
 
@@ -93,16 +94,19 @@ class carbMesh():
                 # Elevation at time of deposition (paleo-depth)
                 self.paleoDepth = numpy.zeros((self.ptsNb,layNb+eroLay),order='F')
                 self.layerThick = numpy.zeros((self.ptsNb,layNb+eroLay),order='F')
+
                 self.paleoDepth[:,:eroLay] = paleoDepth
                 # Deposition thickness for each type of sediment
                 self.depoThick = numpy.zeros((self.ptsNb,layNb+eroLay,self.nbSed),order='F')
-                for r in range(4):
+
+                for r in range(nbSed-1):
                     self.depoThick[:,:eroLay,r] = numpy.array((df['/depoThickRock'+str(r)]))
                 self.layerThick[:,:eroLay] = numpy.sum(self.depoThick[:,:eroLay,:],axis=-1)
             
-            else:
-                #Version for UW coupling case
-                # In the UW coupling case, the loaded data is not directly assigned to the self.paleoDepth
+            elif DispX_Flag==True:
+                print("3D disp- case")
+                #Version for Horizontal displacements case
+                # The loaded data is not directly assigned to the self.paleoDepth
                 #and self.layerthick. This process is instead done in the load_hdf5_carb fn
                 if os.path.exists(rfolder):
                     folder = rfolder+'/h5/'

--- a/badlands/badlands/underland/carbMesh.py
+++ b/badlands/badlands/underland/carbMesh.py
@@ -59,10 +59,6 @@ class carbMesh():
         self.tinBase = None
         self.nbSed = nbSed
         
-        ####FOR RE-STARTING
-        self.loaded_paleoDepth= None
-        
-
         if self.baseMap is not None:
             self._build_basement(xyTIN,bPts,regX,regY)
 

--- a/badlands/setup.py
+++ b/badlands/setup.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
         author="Tristan Salles",
         author_email="tristan.salles@sydney.edu.au",
         url="https://github.com/badlands-model",
-        version="2.2.3",
+        version="2.2.4",
         description="Basin and Landscape Dynamics (Badlands) is a TIN-based landscape evolution model",
         long_description=long_description,
         long_description_content_type="text/markdown",


### PR DESCRIPTION
This implementation enables the use of 3D displacements when using both the Carbonate growth and wave modules. The carbonate module now includes a "Pelagic rain proportion" which is independent of the clastic, species1 and species2 proportions previously implemented. Furthermore, this version also addresses the issue with the checkpointing of .sed files when running Underworld-Bdls coupled models by rounding to 0 decimal positions the time steps injected into Bdls from Underworld. 